### PR TITLE
Update Markdown Link Check to Linkspector

### DIFF
--- a/.github/other-configs/.linkspector.yml
+++ b/.github/other-configs/.linkspector.yml
@@ -1,0 +1,5 @@
+files:
+  - README.md
+  - LICENSE
+aliveStatusCodes:
+  - 200

--- a/.github/other-configs/markdown-check-links.json
+++ b/.github/other-configs/markdown-check-links.json
@@ -1,5 +1,0 @@
-{
-  "aliveStatusCodes": [200],
-  "ignorePatterns": [],
-  "timeout": "5s"
-}

--- a/.github/workflows/code-lint-and-format-checks.yml
+++ b/.github/workflows/code-lint-and-format-checks.yml
@@ -16,7 +16,7 @@ jobs:
     name: Check Code Quality
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -33,7 +33,7 @@ jobs:
     name: Check Justfile Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -46,21 +46,21 @@ jobs:
     name: Check Markdown links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check Markdown links
-        uses: gaurav-nelson/github-action-markdown-link-check@v1
+        uses: UmbrellaDocs/action-linkspector@v1.1.3
         with:
-          config-file: .github/other-configs/markdown-check-links.json
-          base-branch: main
-          check-modified-files-only: "no"
+          reporter: github-pr-review
+          fail_on_error: true
 
   check-go-format:
     name: Check Go Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/code-test.yml
+++ b/.github/workflows/code-test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Code Test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
# Pull Request

## Description

Swaps Markdown Link Checker with Linkspector which is now the recommended link checker tool.

fixes #32 