### PR TITLE
ci: Workflow to Sync Labels

### DIFF
--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -1,0 +1,57 @@
+# Default GitHub labels
+- color: d73a4a
+  name: bug
+  description: Something isn't working
+- color: 0075ca
+  name: documentation
+  description: Improvements or additions to documentation
+- color: 0366d6
+  name: dependencies
+  description: Pull requests that update a dependency file
+- color: cfd3d7
+  name: duplicate
+  description: This issue or pull request already exists
+- color: a2eeef
+  name: enhancement
+  description: Functionality that enhances existing features
+- color: 7057ff
+  name: good first issue
+  description: Good for newcomers
+- color: 008672
+  name: help wanted
+  description: We are looking for community help
+- color: e4e669
+  name: invalid
+  description: This doesn't seem right
+- color: d876e3
+  name: question
+  description: Further information is requested
+- color: d876e3
+  name: wontfix
+  description: The issue is expected and will not be fixed
+# Release Please
+- color: ededed
+  name: "autorelease: pending"
+  description:
+- color: ededed
+  name: "autorelease: tagged"
+  description:
+- color: ededed
+  name: "autorelease: triggered"
+  description:
+- color: ededed
+  name: "autorelease: snapshot"
+  description:
+- color: ededed
+  name: "autorelease: published"
+  description:
+# Languages
+- color: 006B75
+  name: go
+  description: Pull requests that update Go code
+- color: 000000
+  name: github_actions
+  description: Pull requests that update GitHub Actions code
+- color: 66A615
+  name: just
+  description: Pull requests that update Just code

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,26 @@
+name: "Sync labels"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/other-configurations/labels.yml
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  configure-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: micnncim/action-label-syncer@v1.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          manifest: .github/other-configurations/labels.yml

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
-          manifest: .github/other-configurations/labels.yml
+          manifest: .github/other-configs/labels.yml


### PR DESCRIPTION
# Pull Request

## Description

Labels can now be created through a configuration file and synced on each merge to main. Once labels are ready a job can run and auto label PRs

fixes #49 