### PR TITLE
ci: Fix Markdown Link Check on CHANGELOG.md

### DIFF
--- a/.github/other-configs/.linkspector.yml
+++ b/.github/other-configs/.linkspector.yml
@@ -1,9 +1,6 @@
-files:
-  - README.md
-  - LICENSE
-  - docs/*.md
-  - docs/**/*.md
+dirs:
+  - ./
 excludedFiles:
-  - CHANGELOG.md
+  - ./CHANGELOG.md
 aliveStatusCodes:
   - 200

--- a/.github/workflows/code-lint-and-format-checks.yml
+++ b/.github/workflows/code-lint-and-format-checks.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           LINTER_RULES_PATH: .github/super-linter-configs
           YAML_ERROR_ON_WARNING: true
 
@@ -54,7 +54,7 @@ jobs:
         uses: UmbrellaDocs/action-linkspector@v1.1.3
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          config_file: .github/other-configs/.linkspector.yaml
+          config_file: .github/other-configs/.linkspector.yml
           reporter: github-pr-review
           fail_on_error: true
           filter_mode: nofilter


### PR DESCRIPTION
# Pull Request

## Description

Fix Linkspector checking markdown links in CHANGELOG.md as comparison doesn't yet exist.