### PR TITLE
chore: Update Pull Request Title Checker

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -67,12 +67,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.27.1
+        uses: github/codeql-action/init@v3.27.4
         with:
           languages: go
           queries: security-and-quality
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.27.1
+        uses: github/codeql-action/analyze@v3.27.4
 
   check-go-format:
     name: Check Go Format

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -8,14 +8,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  check-pr-title:
+  check-pull-request-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@v1.0.2
         with:
-          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: " # title should start with the given prefix
+          allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
 
   labeller:
     name: Label Pull Request

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -1,4 +1,4 @@
-name: "Pull Request Checks"
+name: "Pull Request Tasks"
 
 on:
   pull_request:
@@ -27,7 +27,6 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/other-configs/labeller.yml
           sync-labels: true
-
       - name: Add Size Labels
         uses: pascalgn/size-label-action@v0.5.5
         env:


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/pull-request-check.yml` file. The change renames the `check-pr-title` job to `check-pull-request-title` and updates the allowed prefixes for pull request titles.

* [`.github/workflows/pull-request-check.yml`](diffhunk://#diff-a41883675207a8c0228186248dccad408b2145a8beedf025e5e90e387f585e92L11-R18): Renamed the `check-pr-title` job to `check-pull-request-title` and added `build(deps):` to the list of allowed prefixes for pull request titles.

Fixes #100 
