### PR TITLE
chore: Update Repository Labels

### DIFF
--- a/.github/other-configs/labeller.yml
+++ b/.github/other-configs/labeller.yml
@@ -7,7 +7,17 @@ dependencies:
 documentation:
   - any:
       - changed-files:
-          - any-glob-to-any-file: ["README.md", "docs/**/*", "docs/*"]
+          - any-glob-to-any-file: ["README.md", "*.md", "docs/**"]
+markdown:
+  - any:
+      - changed-files:
+          - any-glob-to-any-file:
+              [
+                "docs/*.md",
+                "*.md",
+                "LICENSE",
+                ".github/pull_request_template.md",
+              ]
 go:
   - any:
       - changed-files:
@@ -23,8 +33,7 @@ just:
 github_actions:
   - any:
       - changed-files:
-          - any-glob-to-any-file:
-              [".github/workflows/*", ".github/workflows/**/*"]
+          - any-glob-to-any-file: [".github/workflows/*", ".github/actions/*"]
 tests:
   - any:
       - changed-files:

--- a/.github/other-configs/labels.yml
+++ b/.github/other-configs/labels.yml
@@ -58,6 +58,9 @@
 - color: 66A615
   name: just
   description: Pull requests that update Just code
+- color: 1900ff
+  name: markdown
+  description: Pull requests that update Markdown documentation
 # Components
 - color: ff0073
   name: git_hooks


### PR DESCRIPTION
## Description

This pull request includes updates to the `.github/other-configs` directory to improve the labeling system for pull requests. The most important changes include modifications to the `labeller.yml` and `labels.yml` files to refine the categorization of files and add new labels.

Updates to labeling system:

* [`.github/other-configs/labeller.yml`](diffhunk://#diff-b98efd81d493834a02c6a37eab5defdb637a6c95a1382567c6ca211ba16174b2L10-R20): Added a new `markdown` category for markdown files and updated the `documentation` category to include all markdown files and the `LICENSE` file.
* [`.github/other-configs/labeller.yml`](diffhunk://#diff-b98efd81d493834a02c6a37eab5defdb637a6c95a1382567c6ca211ba16174b2L26-R36): Updated the `github_actions` category to include files in the `.github/actions/` directory.
* [`.github/other-configs/labels.yml`](diffhunk://#diff-2e7c23e626fa8c338aa942fce55a914e6e08b1643901fdd722f4168ea42c78fbR61-R63): Added a new `markdown` label with a description for pull requests that update Markdown documentation.

Fixes #102 