### PR TITLE
chore: Ungroup Major Application Dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,6 @@ updates:
       go:
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/dependabot.yml` file. The change specifies the types of updates that Dependabot should apply to Go dependencies, limiting them to patch and minor updates.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R35-R37): Added `update-types` configuration for Go dependencies to include only `patch` and `minor` updates.

Fixes #110 