### PR TITLE
ci: Add Zizmor Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -119,7 +119,6 @@ jobs:
         uses: extractions/setup-just@v2
       - name: Run Tests
         run: just test
-
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@v3.1.0
         env:
@@ -127,3 +126,28 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: .
+
+  run-zizmor:
+    name: Check GitHub Actions with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4.2.0
+        with:
+          version: "latest"
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3.27.9
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the GitHub Actions workflow configuration to enhance code checks and security scanning. The most important changes include the removal of the SonarCloud scan step and the addition of a new job to run Zizmor for checking GitHub Actions.

Enhancements to code checks and security scanning:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L122-R153): Removed the SonarCloud scan step.
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L122-R153): Added a new job named `run-zizmor` to check GitHub Actions using Zizmor, including steps to install `uv`, run `zizmor`, and upload the SARIF file.

Fixes #115 
