### PR TITLE
chore: Add coverage to SonarCloud

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -6,7 +6,7 @@ build:
     echo TODO
 
 test:
-    echo TODO
+    go test -coverprofile=coverage.out ./...
 
 # ------------------------------------------------------------------------------
 # Go

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,5 @@
 sonar.organization=jackplowman
 sonar.projectKey=JackPlowman_github-pr-analyser
 
-# relative paths to source directories. More details and properties are described
-# in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/
 sonar.sources=.
+sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes changes to the build and testing configuration, as well as updates to the SonarQube project properties to improve test coverage reporting.

### Build and Testing Configuration:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL9-R9): Updated the `test` command to run Go tests with coverage reporting (`go test -coverprofile=coverage.out ./...`).

### SonarQube Configuration:

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL4-R5): Added the `sonar.go.coverage.reportPaths` property to specify the coverage report path (`coverage.out`).

Fixes #127 
