### PR TITLE
chore: Exclude test go files from coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,4 +2,5 @@ sonar.organization=jackplowman
 sonar.projectKey=JackPlowman_github-pr-analyser
 
 sonar.sources=.
+sonar.coverage.exclusions=*_test.go
 sonar.go.coverage.reportPaths=coverage.out


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `sonar-project.properties` file. The change excludes test files from the coverage report.

* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cR5): Added `sonar.coverage.exclusions=*_test.go` to exclude test files from the coverage report.

Fixes #130 
