### PR TITLE
chore: Fix Workflow Triggers

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -2,7 +2,7 @@ name: "Pull Request Tasks"
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, edited, synchronize]
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/pull-request-tasks.yml` file. The change updates the `types` field to include `edited` in addition to `opened` and `synchronize` for the `pull_request` event.

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL5-R5): Added `edited` to the list of `types` for the `pull_request` event.

Fixes #155
