### PR TITLE
chore: Fix Zizmor Warning

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -50,5 +50,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
       - name: Dependency Review
         uses: actions/dependency-review-action@v4.5.0


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a small change to the `.github/workflows/pull-request-tasks.yml` file. The change modifies the `Checkout Repository` step to include additional configuration options for `fetch-depth` and `persist-credentials`.

* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfR53-R55): Added `fetch-depth: 0` and `persist-credentials: false` to the `Checkout Repository` step.
