### PR TITLE
chore: Bump GitHub Action Versions

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -80,13 +80,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.9
+        uses: github/codeql-action/init@v3.28.10
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
           config-file: .github/other-configs/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.9
+        uses: github/codeql-action/analyze@v3.28.10
 
   check-go-format:
     name: Check Go Format
@@ -153,7 +153,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v4.2.0
+        uses: astral-sh/setup-uv@v5.3.0
         with:
           version: "latest"
       - name: Run zizmor 🌈
@@ -161,7 +161,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3.28.9
+        uses: github/codeql-action/upload-sarif@v3.28.10
         with:
           sarif_file: results.sarif
           category: zizmor


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes updates to the versions of several GitHub Actions in the `.github/workflows/code-checks.yml` file. These updates ensure that the latest features and fixes are included in the workflows.

Version updates:

* Updated `github/codeql-action/init` from `v3.28.9` to `v3.28.10` to initialize CodeQL.
* Updated `github/codeql-action/analyze` from `v3.28.9` to `v3.28.10` to perform CodeQL analysis.
* Updated `astral-sh/setup-uv` from `v4.2.0` to `v5.3.0` to install the latest version of `uv`.
* Updated `github/codeql-action/upload-sarif` from `v3.28.9` to `v3.28.10` to upload SARIF files.