### PR TITLE
chore: Remove CodeQL Configuration

### DIFF
--- a/.github/other-configs/codeql-config.yml
+++ b/.github/other-configs/codeql-config.yml
@@ -1,3 +1,0 @@
-query-filters:
-  - exclude:
-      id: actions/unpinned-tag

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -86,7 +86,6 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
-          config-file: .github/other-configs/codeql-config.yml
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.28.10
 


### PR DESCRIPTION
# Pull Request

## Description

This pull request removes a custom CodeQL configuration file and updates the workflow to no longer reference it. These changes simplify the CodeQL setup by relying on default configurations.

CodeQL configuration changes:

* [`.github/other-configs/codeql-config.yml`](diffhunk://#diff-b868036a8a443102b2e66591b454b6e9f8d7dc04cca30fc4e4dddb7d680d7979L1-L3): Removed the file, which previously excluded the `actions/unpinned-tag` query.

Workflow updates:

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L89): Removed the `config-file` parameter pointing to the deleted CodeQL configuration file, allowing the workflow to use default settings.