### PR TITLE
ci: Add Lefthook Validate Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -178,3 +178,19 @@ jobs:
           persist-credentials: false
       - name: Run Local Action
         uses: ./.github/actions/local
+
+  lefthook-validate:
+    name: Lefthook Validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.2.2
+        with:
+          version: "latest"
+      - name: Run Lefthook Validate
+        run: uvx lefthook validate


### PR DESCRIPTION
# Pull Request

## Description

This pull request introduces a new job to the GitHub Actions workflow configuration for validating Lefthook hooks. The addition ensures that Lefthook validation is integrated into the CI pipeline.

### Workflow Enhancements:
* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4R181-R196): Added a new job named `lefthook-validate` to the workflow. This job runs on `ubuntu-latest`, checks out the repository, installs the latest version of `uv`, and executes the `lefthook validate` command to validate Lefthook hooks.
