### PR TITLE
ci: Add Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -194,3 +194,17 @@ jobs:
           version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
+
+  pinact-verify:
+    name: Pinact Verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
+        with:
+          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow for verifying Pinact. It includes steps for checking out the repository and installing the latest version of `uv`.

### Additions to GitHub Actions workflow:
* Added a new job named `pinact-verify` to `.github/workflows/code-checks.yml`. This job runs on `ubuntu-latest` and includes steps to:
  - Checkout the repository using `actions/checkout@v4.2.2` with specific options (`fetch-depth: 0`, `persist-credentials: false`).
  - Install the latest version of `uv` using `astral-sh/setup-uv` action, pinned to a specific commit (`d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86`).
