### PR TITLE
chore: Add Pinact Verify Commit Hook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,3 +18,5 @@ pre-commit:
       run: just lefthook-validate
     Zizmor Checks:
       run: just zizmor-check
+    Pinact Verify:
+      run: just pinact-verify


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new pre-commit hook to the `lefthook.yml` configuration file. The new hook, `Pinact Verify`, runs the `just pinact-verify` command.

* **Pre-commit hook addition**:
  - [`lefthook.yml`](diffhunk://#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884dR21-R22): Added a new pre-commit hook named `Pinact Verify` to execute the `just pinact-verify` command.