### PR TITLE
ci: Remove Pinact Verify Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -194,17 +194,3 @@ jobs:
           version: "latest"
       - name: Run Lefthook Validate
         run: uvx lefthook validate
-
-  pinact-verify:
-    name: Pinact Verify
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
-        with:
-          version: "latest"


### PR DESCRIPTION
# Pull Request

## Description

This pull request includes a change to the `.github/workflows/code-checks.yml` file, specifically removing an unused job configuration to streamline the workflow.

Workflow cleanup:

* Removed the `pinact-verify` job, including its steps for checking out the repository and installing the latest version of `uv`, as it was no longer needed. (`.github/workflows/code-checks.yml`)
