### PR TITLE
chore: Update Dependabot Schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,8 @@ updates:
     commit-message:
       prefix: "deps(github-actions)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,9 +21,8 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     commit-message:
       prefix: "deps(go)"
@@ -41,9 +39,8 @@ updates:
     commit-message:
       prefix: "deps(docker)"
     schedule:
-      interval: "daily"
-      time: "01:00"
-      timezone: "Europe/London"
+      interval: "cron"
+      cronjob: "30 7,12,17 * * *"
     target-branch: "main"
     groups:
       docker:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       prefix: "deps(github-actions)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       github-actions:
@@ -22,7 +22,7 @@ updates:
     directory: "/"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     commit-message:
       prefix: "deps(go)"
@@ -40,7 +40,7 @@ updates:
       prefix: "deps(docker)"
     schedule:
       interval: "cron"
-      cronjob: "30 7,12,17 * * *"
+      cronjob: "30 7 * * *"
     target-branch: "main"
     groups:
       docker:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the Dependabot configuration in `.github/dependabot.yml` to switch from a daily schedule to a cron-based schedule for dependency updates. The new schedule triggers updates at 7:30 AM UTC daily.

### Changes to Dependabot schedule:

* Updated the schedule for `github-actions` dependencies to use a cron job (`30 7 * * *`) instead of a daily interval with a fixed time and timezone. (`.github/dependabot.yml`, [.github/dependabot.ymlL10-R11](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L10-R11))
* Updated the schedule for `gomod` dependencies to use the same cron job (`30 7 * * *`) for consistency. (`.github/dependabot.yml`, [.github/dependabot.ymlL25-R25](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L25-R25))
* Updated the schedule for `docker` dependencies to align with the cron-based schedule (`30 7 * * *`). (`.github/dependabot.yml`, [.github/dependabot.ymlL44-R43](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L44-R43))