### PR TITLE
chore: Update Dependabot Groups and Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,20 @@
 version: 2
+
 updates:
   - package-ecosystem: "github-actions"
-    directories:
-      - "/"
-      - ".github/actions/local"
-    commit-message:
-      prefix: "deps(github-actions)"
+    directory: "/"
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       github-actions:
+        applies-to: "version-updates"
         patterns:
           - "*"
+        exclude-patterns:
+          - "super-linter/*"
         update-types:
           - "patch"
           - "minor"
@@ -23,11 +24,13 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     commit-message:
       prefix: "deps(go)"
     groups:
       go:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:
@@ -41,9 +44,11 @@ updates:
     schedule:
       interval: "cron"
       cronjob: "30 7 * * *"
+      timezone: "Europe/London"
     target-branch: "main"
     groups:
       docker:
+        applies-to: "version-updates"
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to streamline dependency updates and improve scheduling. Key changes include the addition of timezone support, simplification of directory specifications, and enhanced grouping rules for version updates.

### Scheduling improvements:
* Added a `timezone` field (`Europe/London`) to the `schedule` section for better control over update timing. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R27-R33) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R47-R51)

### Configuration simplification:
* Removed redundant `directories` entries and replaced them with a single `directory` field for clarity.

### Grouping enhancements:
* Introduced `applies-to: "version-updates"` in the `groups` section for `github-actions`, `go`, and `docker` ecosystems to better target updates.
* Added an `exclude-patterns` field to the `github-actions` group to exclude updates matching `super-linter/*`. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R2-R17) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R27-R33) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R47-R51)