### PR TITLE
chore: Add Zizmor Configuration

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -80,7 +80,7 @@ lefthook-validate:
 
 # Run zizmor checking
 zizmor-check:
-    zizmor .
+    zizmor . --pedantic --persona=pedantic
 
 # ------------------------------------------------------------------------------
 # Pinact


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `lefthook-validate` configuration in the `Justfile` to enhance the `zizmor` check by adding stricter validation options.

Enhancements to `zizmor` check:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL83-R83): Updated the `zizmor-check` command to include the `--pedantic` flag and set the `persona` to `pedantic`, enabling more rigorous checks during validation.