### PR TITLE
ci: Change Jobs to Common Pull Request Tasks

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -17,45 +17,10 @@ jobs:
         with:
           allowed_prefixes: "feat: ,fix: ,bug: ,ci: ,refactor: ,docs: ,build: ,chore(,deps(,chore: ,feat!: ,fix!: ,refactor!: ,test: ,build(deps): " # title should start with the given prefix
 
-  labeller:
-    name: Label Pull Request
-    runs-on: ubuntu-latest
+  common-pull-request-tasks:
+    name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    steps:
-      - name: Label Pull Request
-        uses: actions/labeler@v5.0.0
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          configuration-path: .github/other-configurations/labeller.yml
-          sync-labels: true
-      - name: Add Size Labels
-        uses: pascalgn/size-label-action@f8edde36b3be04b4f65dcfead05dc8691b374348 # v0.5.5
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          sizes: >
-            {
-              "0": "XS",
-              "40": "S",
-              "100": "M",
-              "200": "L",
-              "800": "XL",
-              "2000": "XXL"
-            }
-
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Dependency Review
-        uses: actions/dependency-review-action@v4.5.0
-        with:
-          comment-summary-in-pr: on-failure
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@14445779094fde883fdb9f65946fcae6c25f46c0 # v2025.05.14.01
+    secrets:
+      workflow_github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## Description

This pull request refactors the GitHub Actions workflow by consolidating multiple jobs into a reusable workflow. The changes simplify the `.github/workflows/pull-request-tasks.yml` file, reducing duplication and improving maintainability.

### Workflow Refactoring:
* Replaced the `labeller` and `dependency-review` jobs with a single `common-pull-request-tasks` job that uses a reusable workflow (`common-pull-request-tasks.yml`) from the `JackPlowman/reusable-workflows` repository. This change centralizes common pull request tasks into a shared workflow.