### PR TITLE
chore: Update Dependabot for Reusable Workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,8 @@ updates:
         patterns:
           - "*"
         exclude-patterns:
-          - "super-linter/*"
+          - "super-linter/super-linter"
+          - "JackPlowman/reusable-workflows"
         update-types:
           - "patch"
           - "minor"


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the `.github/dependabot.yml` configuration to refine the excluded patterns for dependency updates.

Configuration updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L17-R18): Adjusted the `exclude-patterns` section to specifically exclude `super-linter/super-linter` and `JackPlowman/reusable-workflows` from dependency updates.