### PR TITLE
ci: Fix reusable workflow

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -37,7 +37,7 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       security-events: write
     uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@72df376b6d16d40834a212c93d2869295e4d9b39 # v2025.05.24.02
     secrets:


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a small but significant change to the permissions in the `.github/workflows/code-checks.yml` file, updating the `pull-requests` permission from `read` to `write`.

* [`.github/workflows/code-checks.yml`](diffhunk://#diff-ddf88e15b08104435ae66be9982938335f6c290a85de4cb9a09868e0e01dd4d4L40-R40): Changed `pull-requests` permission from `read` to `write` under the `jobs:` section to enable workflows requiring write access to pull requests.
