### PR TITLE
deps(github-actions): Bump JackPlowman/reusable-workflows to 2025.06.06.01

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -12,6 +12,6 @@ jobs:
     name: Clean Caches
     permissions:
       contents: read
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-clean-caches.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -37,9 +37,10 @@ jobs:
     name: Common Code Checks
     permissions:
       contents: read
+      actions: read
       pull-requests: write
       security-events: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-code-checks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +52,7 @@ jobs:
     strategy:
       matrix:
         language: [actions, go]
-    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/codeql-analysis.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     with:
       language: ${{ matrix.language }}
 

--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -21,6 +21,6 @@ jobs:
     name: Common Pull Request Tasks
     permissions:
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-pull-request-tasks.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@488ca90a2083f1b426771512d204a2d6860d828e # v2025.06.04.02
+    uses: JackPlowman/reusable-workflows/.github/workflows/common-sync-labels.yml@5449fecafeab1261b3267ab11f076ff5ed3bd935 # v2025.06.06.01
     secrets:
       workflow_github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -82,10 +82,6 @@ lefthook-validate:
 zizmor-check:
     uvx zizmor . --persona=pedantic
 
-# Run zizmor checking with sarif output
-zizmor-check-sarif:
-    uvx zizmor . --persona=pedantic --format sarif > results.sarif
-
 # ------------------------------------------------------------------------------
 # Pinact
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates several GitHub Actions workflows to use newer versions of reusable workflows and removes a redundant command from the `Justfile`. These changes ensure compatibility with the latest workflow versions and simplify the project configuration.

### Workflow updates:

* [`.github/workflows/clean-caches.yml`](diffhunk://#diff-d0394e4336a74cdfc1d4cff05d056b893ac7ff922eacf4448e104a754f386b8dL15-R15): Updated the reusable workflow version for cache cleaning to `v2025.06.06.01`.
* `.github/workflows/code-checks.yml`: 
  - Updated the reusable workflow version for code checks to `v2025.06.06.01`.
  - Added `actions: read` permission to the workflow configuration.
  - Updated the reusable workflow version for CodeQL analysis to `v2025.06.06.01`.
* [`.github/workflows/pull-request-tasks.yml`](diffhunk://#diff-ba6496a5b7a58ac3681ed047691dc32281cc7d548fff1d41201babbd65ad45cfL24-R24): Updated the reusable workflow version for pull request tasks to `v2025.06.06.01`.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6L18-R18): Updated the reusable workflow version for label synchronization to `v2025.06.06.01`.

### Configuration simplification:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL85-L88): Removed the `zizmor-check-sarif` command, which was redundant and unused.