### PR TITLE
ci: Add Go Dependency Vulnerability Checks

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -39,16 +39,6 @@ jobs:
     with:
       language: ${{ matrix.language }}
 
-  go-vul-check:
-    name: Run Go Vulnerability Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Go Vulnerability Check
-        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
-        with:
-          go-version-file: ./go.mod
-          work-dir: .
-
   unit-tests:
     name: Run Unit Tests
     runs-on: ubuntu-latest
@@ -107,3 +97,19 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: v2.4.0
+
+  run-go-dependency-vulnerability-checks:
+    name: Run Go Dependency Vulnerability Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Go dependencies
+        uses: ./.github/actions/setup-go-dependencies
+      - name: Install Go Vulnerability Checker
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run Go Vulnerability Checker
+        run: just vulncheck


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates how Go dependency vulnerability checks are run in the GitHub Actions workflow. The main change is replacing the previous use of the `govulncheck-action` with a custom job that installs and runs the vulnerability checker directly. This makes the process more flexible and consistent with other job setups.

**Go vulnerability checking workflow changes:**

* Removed the `go-vul-check` job that used the `golang/govulncheck-action` to run vulnerability checks on Go dependencies.
* Added a new job, `run-go-dependency-vulnerability-checks`, which checks out the repository, sets up Go dependencies using a custom action, installs the Go vulnerability checker manually, and runs it using the `just vulncheck` command.

Fixes #315
