### PR TITLE
ci: Add Go Build Job

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -114,6 +114,20 @@ jobs:
       - name: Run Go Vulnerability Checker
         run: just vulncheck
 
+  go-build:
+    name: Go Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up Go dependencies
+        uses: ./.github/actions/setup-go-dependencies
+      - name: Build
+        run: just build
+
   go-dependency-submission:
     name: Go Dependency Submission
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds a new job to the GitHub Actions workflow to ensure that Go code is built and checked during CI. The main change is the introduction of a `go-build` job to the `.github/workflows/code-checks.yml` file.

**Continuous Integration improvements:**

* Added a `go-build` job to `.github/workflows/code-checks.yml` that checks out the repository, sets up Go dependencies, and runs the build process using `just build`, ensuring Go code is built and validated as part of CI.

Fixes #311