### PR TITLE
build: Use go-enry to determine language from file extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-enry/go-enry/v2 v2.9.2 // indirect
+	github.com/go-enry/go-oniguruma v1.2.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-enry/go-enry/v2 v2.9.2 h1:giOQAtCgBX08kosrX818DCQJTCNtKwoPBGu0qb6nKTY=
+github.com/go-enry/go-enry/v2 v2.9.2/go.mod h1:9yrj4ES1YrbNb1Wb7/PWYr2bpaCXUGRt0uafN0ISyG8=
+github.com/go-enry/go-oniguruma v1.2.1 h1:k8aAMuJfMrqm/56SG2lV9Cfti6tC4x8673aHCcBk+eo=
+github.com/go-enry/go-oniguruma v1.2.1/go.mod h1:bWDhYP+S6xZQgiRL7wlTScFYBe023B6ilRZbCAD5Hf4=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
@@ -28,6 +32,7 @@ golang.org/x/oauth2 v0.30.0/go.mod h1:B++QgG3ZKulg6sRPGD/mqlHQs5rB3Ml9erfeDY7xKl
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/main.go
+++ b/src/main.go
@@ -107,7 +107,8 @@ func analyseFileTypes(files []*github.CommitFile) []FileStats {
 		if language == "" {
 			language = "Unknown"
 		}
-		zap.L().Debug("File analysed", zap.String("filename", *file.Filename), zap.String("language", language))
+		zap.L().
+			Debug("File analysed", zap.String("filename", *file.Filename), zap.String("language", language))
 		languageMap[language]++
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -50,7 +50,7 @@ func generatePRFileAnalysis() string {
 		return "```markdown\nNo files changed in this PR.\n```"
 	}
 
-	stats := analyzeFileTypes(files)
+	stats := analyseFileTypes(files)
 	return formatFileStats(stats, len(files))
 }
 
@@ -94,8 +94,8 @@ func getPRFiles() []*github.CommitFile {
 	return files
 }
 
-// analyzeFileTypes analyzes file types and returns statistics
-func analyzeFileTypes(files []*github.CommitFile) []FileStats {
+// analyseFileTypes analyses file types and returns statistics
+func analyseFileTypes(files []*github.CommitFile) []FileStats {
 	languageMap := make(map[string]int)
 	totalFiles := len(files)
 
@@ -104,7 +104,10 @@ func analyzeFileTypes(files []*github.CommitFile) []FileStats {
 			continue
 		}
 		language, _ := enry.GetLanguageByExtension(*file.Filename)
-		zap.L().Debug("File analyzed", zap.String("filename", *file.Filename), zap.String("language", language))
+		if language == "" {
+			language = "unknown"
+		}
+		zap.L().Debug("File analysed", zap.String("filename", *file.Filename), zap.String("language", language))
 		languageMap[language]++
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/go-enry/go-enry/v2"
 	"github.com/google/go-github/v74/github"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
@@ -103,7 +103,8 @@ func analyzeFileTypes(files []*github.CommitFile) []FileStats {
 		if file.Filename == nil {
 			continue
 		}
-		language := getLanguageFromExtension(*file.Filename)
+		language, _ := enry.GetLanguageByExtension(*file.Filename)
+		zap.L().Debug("File analyzed", zap.String("filename", *file.Filename), zap.String("language", language), zap.Error(err))
 		languageMap[language]++
 	}
 
@@ -123,50 +124,6 @@ func analyzeFileTypes(files []*github.CommitFile) []FileStats {
 	})
 
 	return stats
-}
-
-// getLanguageFromExtension maps file extensions to language names
-func getLanguageFromExtension(filename string) string {
-	ext := strings.ToLower(filepath.Ext(filename))
-
-	extensionMap := map[string]string{
-		".py":    "Python",
-		".md":    "Markdown",
-		".tex":   "TeX",
-		".html":  "HTML",
-		".htm":   "HTML",
-		".js":    "JavaScript",
-		".ts":    "TypeScript",
-		".go":    "Go",
-		".java":  "Java",
-		".cpp":   "C++",
-		".c":     "C",
-		".cs":    "C#",
-		".php":   "PHP",
-		".rb":    "Ruby",
-		".rs":    "Rust",
-		".sh":    "Shell",
-		".yaml":  "YAML",
-		".yml":   "YAML",
-		".json":  "JSON",
-		".xml":   "XML",
-		".css":   "CSS",
-		".scss":  "SCSS",
-		".sass":  "Sass",
-		".sql":   "SQL",
-		".r":     "R",
-		".kt":    "Kotlin",
-		".swift": "Swift",
-		".dart":  "Dart",
-		".vue":   "Vue",
-		".jsx":   "JSX",
-		".tsx":   "TSX",
-	}
-
-	if language, exists := extensionMap[ext]; exists {
-		return language
-	}
-	return "Other"
 }
 
 // formatFileStats formats the file statistics into markdown

--- a/src/main.go
+++ b/src/main.go
@@ -104,7 +104,7 @@ func analyzeFileTypes(files []*github.CommitFile) []FileStats {
 			continue
 		}
 		language, _ := enry.GetLanguageByExtension(*file.Filename)
-		zap.L().Debug("File analyzed", zap.String("filename", *file.Filename), zap.String("language", language), zap.Error(err))
+		zap.L().Debug("File analyzed", zap.String("filename", *file.Filename), zap.String("language", language))
 		languageMap[language]++
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -105,7 +105,7 @@ func analyseFileTypes(files []*github.CommitFile) []FileStats {
 		}
 		language, _ := enry.GetLanguageByExtension(*file.Filename)
 		if language == "" {
-			language = "unknown"
+			language = "Unknown"
 		}
 		zap.L().Debug("File analysed", zap.String("filename", *file.Filename), zap.String("language", language))
 		languageMap[language]++

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -47,7 +47,7 @@ func TestAnalyseFileTypes(t *testing.T) {
 
 	stats := analyseFileTypes(files)
 
-	// Verify results - should have 6 unique languages: Python, Markdown, CSS, JavaScript, JSON, Other
+	// Verify results - should have 6 unique languages: Python, Markdown, CSS, JavaScript, JSON, Unknown
 	assert.Len(t, stats, 6)
 
 	// Find Python stats (should be first due to sorting by count)
@@ -56,17 +56,17 @@ func TestAnalyseFileTypes(t *testing.T) {
 	assert.Equal(t, 3, pythonStats.Count)
 	assert.Equal(t, float64(30), pythonStats.Percentage)
 
-	// Find Other stats
-	var otherStats FileStats
+	// Find Unknown stats
+	var unknownStats FileStats
 	for _, stat := range stats {
-		if stat.Language == "Other" {
-			otherStats = stat
+		if stat.Language == "Unknown" {
+			unknownStats = stat
 			break
 		}
 	}
-	assert.Equal(t, "Other", otherStats.Language)
-	assert.Equal(t, 2, otherStats.Count)
-	assert.Equal(t, float64(20), otherStats.Percentage)
+	assert.Equal(t, "Unknown", unknownStats.Language)
+	assert.Equal(t, 2, unknownStats.Count)
+	assert.Equal(t, float64(20), unknownStats.Percentage)
 }
 
 func TestFormatFileStats(t *testing.T) {

--- a/src/main_test.go
+++ b/src/main_test.go
@@ -30,42 +30,7 @@ func TestGitHubActionSummary(t *testing.T) {
 	os.Unsetenv("GITHUB_STEP_SUMMARY")
 }
 
-func TestGetLanguageFromExtension(t *testing.T) {
-	tests := []struct {
-		filename string
-		expected string
-	}{
-		{"main.py", "Python"},
-		{"README.md", "Markdown"},
-		{"document.tex", "TeX"},
-		{"index.html", "HTML"},
-		{"script.js", "JavaScript"},
-		{"app.ts", "TypeScript"},
-		{"main.go", "Go"},
-		{"App.java", "Java"},
-		{"program.cpp", "C++"},
-		{"code.c", "C"},
-		{"Program.cs", "C#"},
-		{"script.php", "PHP"},
-		{"app.rb", "Ruby"},
-		{"main.rs", "Rust"},
-		{"script.sh", "Shell"},
-		{"config.yaml", "YAML"},
-		{"data.json", "JSON"},
-		{"styles.css", "CSS"},
-		{"unknown.xyz", "Other"},
-		{"no-extension", "Other"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.filename, func(t *testing.T) {
-			result := getLanguageFromExtension(test.filename)
-			assert.Equal(t, test.expected, result)
-		})
-	}
-}
-
-func TestAnalyzeFileTypes(t *testing.T) {
+func TestAnalyseFileTypes(t *testing.T) {
 	// Create mock files
 	files := []*github.CommitFile{
 		{Filename: stringPtr("main.py")},
@@ -80,7 +45,7 @@ func TestAnalyzeFileTypes(t *testing.T) {
 		{Filename: stringPtr("no-ext")},
 	}
 
-	stats := analyzeFileTypes(files)
+	stats := analyseFileTypes(files)
 
 	// Verify results - should have 6 unique languages: Python, Markdown, CSS, JavaScript, JSON, Other
 	assert.Len(t, stats, 6)


### PR DESCRIPTION
# Pull Request

## Description

This pull request updates the logic for detecting file languages in the repository by replacing a manual extension mapping with the more robust `go-enry` library. This change improves accuracy and maintainability. It also adds logging for language detection and removes unused imports and code.

**File language detection improvements:**

* Replaced the custom `getLanguageFromExtension` function with the `go-enry` library’s `GetLanguageByExtension` function in `src/main.go`, providing more accurate and comprehensive language detection.
* Added the `github.com/go-enry/go-enry/v2` and `github.com/go-enry/go-oniguruma` dependencies to `go.mod` to support the new language detection logic.

**Codebase cleanup and logging:**

* Removed the unused `filepath` import from `src/main.go` since it’s no longer needed for extension parsing.
* Added a debug log statement to output the filename and detected language for each file analyzed, aiding troubleshooting and transparency.
* Deleted the entire `getLanguageFromExtension` function and its extension map from `src/main.go`, as it is now obsolete.

## Pull Request Change Statistics

```markdown
Files changed: 4

Go                  2 files changed >>>>>>>>>>>>-------------   50 %
AMPL                1 files changed >>>>>>-------------------   25 %
Unknown             1 files changed >>>>>>-------------------   25 %
```

Fixes #332
