### PR TITLE
chore: Add Go Lint pre-commit hooks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,3 +20,7 @@ pre-commit:
       run: just zizmor-check
     Pinact Check:
       run: just pinact-check
+    Go Lint Check:
+      run: just lint
+    Go Vulnerability Check:
+      run: just vulncheck


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds new automated checks to the `pre-commit` section of the `lefthook.yml` configuration to improve code quality and security for Go projects.

New Go-related pre-commit checks:

* Added a Go linting step that runs `just lint` to enforce coding standards.
* Added a Go vulnerability check that runs `just vulncheck` to scan for security issues in dependencies.

## Pull Request Change Statistics

```markdown
Files changed: 1

MiniYAML            1 files changed >>>>>>>>>>>>>>>>>>>>>>>>>   100 %
```

Fixes #340
