### PR TITLE
ci: Update Pull Request Tasks Permissions

### DIFF
--- a/.github/workflows/pull-request-tasks.yml
+++ b/.github/workflows/pull-request-tasks.yml
@@ -4,13 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   check-pull-request-title:
     name: Check Pull Request Title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - name: Check Pull Request Title
         uses: deepakputhraya/action-pr-title@3864bebc79c5f829d25dd42d3c6579d040b0ef16 # v1.0.2


### PR DESCRIPTION
# Pull Request

## Description

This pull request makes a minor update to the GitHub Actions workflow configuration by relocating the `pull-requests: read` permission from the top-level `permissions` block to the job-specific `permissions` block for the `check-pull-request-title` job. This change ensures that only the relevant job is granted the necessary permissions, improving the principle of least privilege.

- Workflow permissions update:
  * Moved the `pull-requests: read` permission from the global workflow level to the `check-pull-request-title` job level in `.github/workflows/pull-request-tasks.yml`, setting the top-level permissions to an empty object.